### PR TITLE
Fixed spelling error "Mardown" in output

### DIFF
--- a/src/smdOutputProvider.ts
+++ b/src/smdOutputProvider.ts
@@ -11,7 +11,7 @@ export class SMLTextWriter {
 
 	public static displaySSMLText(smdText : string) {
 		  
-	  var output : string = 'Speech Mardown text: \n';
+	  var output : string = 'Speech Markdown text: \n';
 	  
 	  if(smdText.length == 0)
 	  {

--- a/src/ssmlAudioPlayer.ts
+++ b/src/ssmlAudioPlayer.ts
@@ -21,7 +21,7 @@ export class SSMLAudioPlayer {
 
 	public static async getSSMLSpeechAsync(smdText : string, engineType: Engine) {
 		  
-	  var output : string = 'Speech Mardown text: \n';
+	  var output : string = 'Speech Markdown text: \n';
 	  
 
 	  if(smdText.length == 0)


### PR DESCRIPTION
I noticed a spelling error in the SSML output that was an easy fix across two files.